### PR TITLE
Renamed 'event' to 'msg_type' because in some programming languages '…

### DIFF
--- a/KeyValueStore.lua
+++ b/KeyValueStore.lua
@@ -23,7 +23,7 @@ end
 function _M.sendUpdates()
 	local MAX_UPDATES_AT_ONCE = 100
 	local datacount = 0
-	msg = { event="newdata", data = {} }
+	msg = { msg_type="newdata", data = {} }
 	for k, _ in pairs(_M.dirty) do
 		if datacount >= MAX_UPDATES_AT_ONCE then
 			_M.sendMessage(msg)

--- a/Protocol.lua
+++ b/Protocol.lua
@@ -50,7 +50,7 @@ function _M.newUnit(unitType)
 	_M.exportedLuaFunctions = {}
 	_M.KVS.reset()
 	_M.sendMessage({
-		["event"] = "new_unit",
+		["msg_type"] = "new_unit",
 		["type"] = unitType
 	})
 end

--- a/README.md
+++ b/README.md
@@ -35,12 +35,12 @@ Examples:
 # Messages from DCS
 
 ## newdata
-Example: `{"event":"newdata", "data":{"_UNITTYPE":"A-10C","c404":0}}`
+Example: `{"msg_type":"newdata", "data":{"_UNITTYPE":"A-10C","c404":0}}`
 
-If the "event" attribute is "newdata", the "data" attribute is an object that contains a key => value mapping of all keys that have changed since the last "newdata" event.
+If the "msg_type" attribute is "newdata", the "data" attribute is an object that contains a key => value mapping of all keys that have changed since the last "newdata" event.
 
 ## new_unit
-Example: `{"event":"new_unit","type":"A-10C"}`
+Example: `{"msg_type":"new_unit","type":"A-10C"}`
 
 When a new unit is entered, this event is sent out. The "type" attribute lists the unit type. "type" can also be "NONE" when there is no active unit (e.g. spectator mode in multiplayer).
 


### PR DESCRIPTION
…event' is a reserved keyword.
